### PR TITLE
Avoid namespace pollution

### DIFF
--- a/src/axp20x.cpp
+++ b/src/axp20x.cpp
@@ -710,21 +710,21 @@ int AXP20X_Class::setChgLEDMode(uint8_t mode)
     _readByte(AXP202_OFF_CTL, 1, &val);
     val |= BIT_MASK(3);
     switch (mode) {
-    case LED_OFF:
+    case AXP20X_LED_OFF:
         val &= 0b11001111;
         _writeByte(AXP202_OFF_CTL, 1, &val);
         break;
-    case LED_BLINK_1HZ:
+    case AXP20X_LED_BLINK_1HZ:
         val &= 0b11001111;
         val |= 0b00010000;
         _writeByte(AXP202_OFF_CTL, 1, &val);
         break;
-    case LED_BLINK_4HZ:
+    case AXP20X_LED_BLINK_4HZ:
         val &= 0b11001111;
         val |= 0b00100000;
         _writeByte(AXP202_OFF_CTL, 1, &val);
         break;
-    case LED_LOW_LEVEL:
+    case AXP20X_LED_LOW_LEVEL:
         val &= 0b11001111;
         val |= 0b00110000;
         _writeByte(AXP202_OFF_CTL, 1, &val);

--- a/src/axp20x.h
+++ b/src/axp20x.h
@@ -354,7 +354,7 @@ typedef enum {
     AXP202_BATT_CONNECT_IRQ = 1 << 15,
     //IRQ3
     AXP202_PEK_LONGPRESS_IRQ = 1 << 16,
-    AXP202_PEL_SHORTPRESS_IRQ   =   1 << 17,
+    AXP202_PEK_SHORTPRESS_IRQ = 1 << 17,
     AXP202_LDO3_LOW_VOL_IRQ = 1 << 18,
     AXP202_DC3_LOW_VOL_IRQ = 1 << 19,
     AXP202_DC2_LOW_VOL_IRQ = 1 << 20,
@@ -395,10 +395,10 @@ typedef enum {
 } axp_ldo4_table_t;
 
 typedef enum {
-    LED_OFF,
-    LED_BLINK_1HZ,
-    LED_BLINK_4HZ,
-    LED_LOW_LEVEL,
+    AXP20X_LED_OFF,
+    AXP20X_LED_BLINK_1HZ,
+    AXP20X_LED_BLINK_4HZ,
+    AXP20X_LED_LOW_LEVEL,
 } axp_chgled_mode_t;
 
 


### PR DESCRIPTION
Lewis,
some name definitions conflict with external ones when this library is in use by other components.
To be specific - **LED_OFF**
This patch contains an update that could mitigate this issue.
