### PR TITLE
Fix setPowerDownVoltage and getPowerDownVoltage

### DIFF
--- a/src/axp20x.cpp
+++ b/src/axp20x.cpp
@@ -1974,7 +1974,7 @@ int AXP20X_Class::setPowerDownVoltage(uint16_t mv)
     uint8_t val  = 0;
     ret = _readByte(AXP202_VOFF_SET, 1, &val);
     if (ret != 0)return AXP_FAIL;
-    val &= AXP202_VOFF_MASK;
+    val &= ~(AXP202_VOFF_MASK);
     val |= ((mv - 2600) / 100);
     ret = _writeByte(AXP202_VOFF_SET, 1, &val);
     if (ret != 0)return AXP_FAIL;
@@ -1987,7 +1987,7 @@ uint16_t AXP20X_Class::getPowerDownVoltage(void)
     uint8_t val  = 0;
     ret = _readByte(AXP202_VOFF_SET, 1, &val);
     if (ret != 0)return 0;
-    val &= ~(AXP202_VOFF_MASK);
+    val &= AXP202_VOFF_MASK;
     uint16_t voff = val * 100 + 2600;
     return voff;
 }

--- a/src/axp20x.h
+++ b/src/axp20x.h
@@ -305,7 +305,7 @@ github:https://github.com/lewisxhe/AXP202X_Libraries
 #define IS_OPEN(reg, channel)                   (bool)(reg & _BV(channel))
 
 
-#define AXP202_VOFF_MASK                        (0x03)
+#define AXP202_VOFF_MASK                        (0x07)
 #define AXP202_LIMIT_MASK                       (0x03)
 #define AXP192_LIMIT_MASK                       (0x01)
 #define AXP192_LIMIT_EN_MASK                    (0x02)


### PR DESCRIPTION
Bitmask was too narrow and was applied in the wrong way.
Not all available values of the power down voltage registers were available.
getPowerDownVoltage did not show the set value.